### PR TITLE
Add clearTimer method

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,22 @@ var timeInMS = timing.stopTimer("Database Query");
 // the time value is always in milliseconds!
 timing.addMetric("Image Processing", 12847)
 
+// If an operation you are timing fails before the
+// timer can be stopped, you can clear that timer
+try {
+  timing.startTimer('Failed Operation');
+  throw new Error('The operation failed!');
+  timing.stopTimer('Failed Operation');
+} catch (e) {
+  timing.clearTimer('Failed Operation');
+}
+
 // ... use the header string within your server framework or whatever
 res.setHeader("Server-Timing", timing.generateHeader());
 return res.send({whatever: "you want"});
 
 // this will output:
-// database-query=0.122; "Database Query",image-processing=12.365; "Image Processing"
+// database-query=0.122; "Database Query",image-processing=12.847; "Image Processing"
 ```
 
 See the <a href="https://github.com/thomasbrueggemann/node-servertiming/tree/master/example">/example</a> folder for a detailed express.js example!

--- a/index.js
+++ b/index.js
@@ -47,6 +47,27 @@ class ServerTiming {
 		return this.times[slug];
 	}
 
+	// CLEAR TIMER
+	clearTimer(name) {
+
+		// slugify name
+		var slug = slugify(name).toLowerCase();
+		if(!slug || slug.length === 0) return false;
+
+		// check if timer even exists
+		if(this.metrics && !(slug in this.metrics)) return false;
+
+		// stop and destory timer
+		Timer.get(slug).stop();
+		Timer.destroy(slug);
+
+		// delete references to this slug
+		delete this.metrics[slug];
+		delete this.times[slug];
+
+		return true;
+	}
+
 	// ADD METRIC
 	addMetric(name, value) {
 

--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,16 @@ describe("Server-Timing ", function() {
 		return done();
 	});
 
+	it("should NOT have reference to timer after it is cleared", function(done) {
+
+		timing.startTimer("Failed Operation");
+		timing.clearTimer("Failed Operation");
+		var header = timing.generateHeader();
+		header.indexOf("Failed Operation").should.equal(-1);
+
+		return done();
+	});
+
 	it("should print the Server-Timing header string", function(done) {
 
 		var header = timing.generateHeader();


### PR DESCRIPTION
If a timer is started and an error is thrown  before that timer is able to be stopped, it would be useful to have a method to clear that timer later (inside a catch block, for example). Without this, a timer that is not stopped or cleared will result in NaN being rendered by the `generateHeader` call.

Example usage:

```javascript
try {
  timing.startTimer('Failed Operation');
  throw new Error('The operation failed for one reason or another!');
  timing.stopTimer('Failed Operation');
} catch (e) {
  timing.clearTimer('Failed Operation');
}
```