### PR TITLE
Update timer-machine dependency to timer-machine-node

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var Timer = require("timer-machine");
+var Timer = require("timer-machine-node");
 var slugify = require("slugify");
 
 // SERVER - TIMING

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/thomasbrueggemann/node-servertiming#readme",
   "dependencies": {
     "slugify": "^1.1.0",
-    "timer-machine": "^1.1.0"
+    "timer-machine-node": "^1.1.1"
   },
   "devDependencies": {
 	"mocha": "*",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/thomasbrueggemann/node-servertiming#readme",
   "dependencies": {
     "slugify": "^1.1.0",
-    "timer-machine-node": "^1.1.1"
+    "timer-machine-node": "^1.1.2"
   },
   "devDependencies": {
 	"mocha": "*",


### PR DESCRIPTION
`timer-machine` package used `new Date().getTime()` as method of measuring lengths of time.

`timer-machine-node` is a fork of that package that instead uses `process.hrtime()`, whose primary purpose is "for measuring performance between intervals".

[This blog](https://blog.tompawlak.org/measure-execution-time-nodejs-javascript) dives deeper into the distinction between these two methods of measuring elapsed time.