### PR TITLE
Server-Timing header is in ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ res.setHeader("Server-Timing", timing.generateHeader());
 return res.send({whatever: "you want"});
 
 // this will output:
-// database-query=0.122; "Database Query",image-processing=12.847; "Image Processing"
+// database-query=122; "Database Query",image-processing=12847; "Image Processing"
 ```
 
 See the <a href="https://github.com/thomasbrueggemann/node-servertiming/tree/master/example">/example</a> folder for a detailed express.js example!

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ class ServerTiming {
 
 		// loop the metrics
 		Object.keys(this.metrics).forEach(slug => {
-			header += slug + "=" + (this.times[slug] / 1000) + "; \"" + this.metrics[slug] + "\",";
+			header += slug + "=" + this.times[slug] + "; \"" + this.metrics[slug] + "\",";
 		});
 
 		// remove trailing comma and return header string


### PR DESCRIPTION
The Server-Timing header uses measurements in milliseconds, not seconds. The timer provides values in milliseconds, so it does not need to be divided by 1000.
I verified this in Chrome 58 that it takes measurements in milliseconds rather than seconds.